### PR TITLE
When the user authenticates, we sync the list of servers and libraries

### DIFF
--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -61,7 +61,7 @@ async def login():
 
     pin_code = request_pin_info.get("code")
     pin_id = request_pin_info.get("id")
-    auth_url = await get_auth_url_from_pin_info(pin_code=pin_code, pin_id=pin_id)
+    auth_url = get_auth_url_from_pin_info(pin_code=pin_code, pin_id=pin_id)
     return RedirectResponse(auth_url)
 
 


### PR DESCRIPTION
Using a session cookie so we don't sync more than once per session

Also removed the specific middleware that was causing conflicts with the session